### PR TITLE
Fix: Infinite click on switch when switch is unknown 

### DIFF
--- a/module/base/switch.py
+++ b/module/base/switch.py
@@ -1,5 +1,6 @@
 from module.base.base import ModuleBase
 from module.base.button import Button
+from module.base.timer import Timer
 from module.logger import logger
 
 
@@ -50,6 +51,7 @@ class Switch:
             bool:
         """
         changed = False
+        warning_show_timer = Timer(5, count=10).start()
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -65,8 +67,12 @@ class Switch:
                     matched = data
                     if current == status:
                         return changed
+
             if current == 'unknown':
-                logger.warning(f'Unknown {self.name} switch')
+                if warning_show_timer.reached():
+                    logger.warning(f'Unknown {self.name} switch')
+                    warning_show_timer.reset()
+                continue
 
             for data in self.status_list:
                 if data['status'] == status:

--- a/module/exercise/combat.py
+++ b/module/exercise/combat.py
@@ -65,7 +65,7 @@ class ExerciseCombat(HpDaemon, OpponentChoose, ExerciseEquipment):
             if self.appear_then_click(EXP_INFO_D):
                 continue
             # Last D rank screen
-            if self.appear_then_click(OPTS_INFO_D, offset=(30,30)):
+            if self.appear_then_click(OPTS_INFO_D, offset=(30, 30)):
                 continue
 
             # Quit

--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -92,22 +92,33 @@ class InfoHandler(ModuleBase):
     """
     Story
     """
+
+    story_popup_timout = Timer(10, count=20)
+
     def story_skip(self):
-        if self.handle_popup_confirm():
-            return True
+        if self.story_popup_timout.started() and not self.story_popup_timout.reached():
+            if self.handle_popup_confirm('STORY_SKIP'):
+                self.story_popup_timout = Timer(10)
+                return True
         if self.appear_then_click(STORY_SKIP, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
-        if self.appear(STORY_LETTER_BLACK) and  self.appear_then_click(STORY_LETTERS_ONLY, offset=True, interval=2):
+        if self.appear(STORY_LETTER_BLACK) and self.appear_then_click(STORY_LETTERS_ONLY, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
         if self.appear_then_click(STORY_CHOOSE, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
         if self.appear_then_click(STORY_CHOOSE_2, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
 
         return False
 
     def handle_story_skip(self):
         if not self.config.ENABLE_MAP_CLEAR_MODE:
+            return False
+        if self.config.ENABLE_FAST_FORWARD:
             return False
 
         return self.story_skip()

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -17,7 +17,7 @@ class UI(ModuleBase):
         """
         return self.appear(page.check_button, offset=(20, 20))
 
-    def ui_click(self, click_button, check_button, appear_button=None, offset=(20, 20), retry_wait=3,
+    def ui_click(self, click_button, check_button, appear_button=None, offset=(20, 20), retry_wait=10,
                  skip_first_screenshot=False):
         """
         Args:


### PR DESCRIPTION
- Increase ui retry interval for potato device
Fix: Click low emotion warn as story confirm when fleet lock disabled