### PR TITLE
Fix: Mis-detection 

### DIFF
--- a/campaign/campaign_main/campaign_12_2_leveling.py
+++ b/campaign/campaign_main/campaign_12_2_leveling.py
@@ -57,11 +57,11 @@ class Campaign(CampaignBase):
 
     def battle_0(self):
         self.check_s3_enemy()
-        if self.clear_enemy(scale=(2,)):
+        if self.clear_enemy(scale=(2,), genre=['light', 'main', 'treasure', 'enemy', 'carrier']):
             return True
         if self.clear_enemy(scale=(1,)):
             return True
-        if self.clear_enemy(scale=(3,)):
+        if self.clear_enemy(scale=(3,), genre=['light', 'carrier', 'enemy', 'treasure', 'main']):
             self.s3_enemy_count += 1
             return True
 

--- a/module/base/base.py
+++ b/module/base/base.py
@@ -18,12 +18,14 @@ class ModuleBase:
         else:
             self.device = Device(config=config)
 
-    def appear(self, button, offset=0, interval=0):
+    def appear(self, button, offset=0, interval=0, threshold=None):
         """
         Args:
             button (Button, Template):
             offset (bool, int):
             interval (int, float): interval between two active events.
+            threshold (int, float): 0 to 1 if use offset, bigger means more similar,
+                0 to 255 if not use offset, smaller means more similar
 
         Returns:
             bool:
@@ -37,9 +39,11 @@ class ModuleBase:
         if offset:
             if isinstance(offset, bool):
                 offset = self.config.BUTTON_OFFSET
-            appear = button.match(self.device.image, offset=offset, threshold=self.config.BUTTON_MATCH_SIMILARITY)
+            appear = button.match(self.device.image, offset=offset,
+                                  threshold=self.config.BUTTON_MATCH_SIMILARITY if threshold is None else threshold)
         else:
-            appear = button.appear_on(self.device.image, threshold=self.config.COLOR_SIMILAR_THRESHOLD)
+            appear = button.appear_on(self.device.image,
+                                      threshold=self.config.COLOR_SIMILAR_THRESHOLD if threshold is None else threshold)
 
         if appear and interval:
             self.interval_timer[button.name].reset()

--- a/module/base/switch.py
+++ b/module/base/switch.py
@@ -1,5 +1,6 @@
 from module.base.base import ModuleBase
 from module.base.button import Button
+from module.base.timer import Timer
 from module.logger import logger
 
 
@@ -50,6 +51,7 @@ class Switch:
             bool:
         """
         changed = False
+        warning_show_timer = Timer(5, count=10).start()
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -65,8 +67,12 @@ class Switch:
                     matched = data
                     if current == status:
                         return changed
+
             if current == 'unknown':
-                logger.warning(f'Unknown {self.name} switch')
+                if warning_show_timer.reached():
+                    logger.warning(f'Unknown {self.name} switch')
+                    warning_show_timer.reset()
+                continue
 
             for data in self.status_list:
                 if data['status'] == status:

--- a/module/combat/combat.py
+++ b/module/combat/combat.py
@@ -230,6 +230,8 @@ class Combat(HPBalancer, EnemySearchingHandler, Retirement, SubmarineCall, Comba
         Returns:
             bool:
         """
+        if self.is_combat_executing():
+            return False
         if self.appear_then_click(BATTLE_STATUS_S, screenshot=save_get_items, genre='status', interval=self.battle_status_click_interval):
             if not save_get_items:
                 self.device.sleep((0.25, 0.5))

--- a/module/exercise/combat.py
+++ b/module/exercise/combat.py
@@ -65,7 +65,7 @@ class ExerciseCombat(HpDaemon, OpponentChoose, ExerciseEquipment):
             if self.appear_then_click(EXP_INFO_D):
                 continue
             # Last D rank screen
-            if self.appear_then_click(OPTS_INFO_D, offset=(30,30)):
+            if self.appear_then_click(OPTS_INFO_D, offset=(30, 30)):
                 continue
 
             # Quit

--- a/module/handler/enemy_searching.py
+++ b/module/handler/enemy_searching.py
@@ -10,6 +10,7 @@ class EnemySearchingHandler(InfoHandler):
     MAP_ENEMY_SEARCHING_OVERLAY_TRANSPARENCY_THRESHOLD = 0.5  # Usually (0.70, 0.80).
     MAP_ENEMY_SEARCHING_TIMEOUT_SECOND = 5
     in_stage_timer = Timer(1.5, count=5)
+    stage_entrance = None
 
     def enemy_searching_color_initial(self):
         MAP_ENEMY_SEARCHING.load_color(self.device.image)
@@ -35,7 +36,12 @@ class EnemySearchingHandler(InfoHandler):
             return False
 
     def is_in_stage(self):
-        return self.appear(IN_STAGE, offset=(10, 10))
+        if not self.appear(IN_STAGE, offset=(10, 10)):
+            return False
+        if self.stage_entrance is not None and not self.appear(self.stage_entrance, threshold=30):
+            return False
+
+        return True
 
     def is_in_map(self):
         return self.appear(IN_MAP)

--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -92,22 +92,33 @@ class InfoHandler(ModuleBase):
     """
     Story
     """
+
+    story_popup_timout = Timer(10, count=20)
+
     def story_skip(self):
-        if self.handle_popup_confirm():
-            return True
+        if self.story_popup_timout.started() and not self.story_popup_timout.reached():
+            if self.handle_popup_confirm('STORY_SKIP'):
+                self.story_popup_timout = Timer(10)
+                return True
         if self.appear_then_click(STORY_SKIP, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
-        if self.appear(STORY_LETTER_BLACK) and  self.appear_then_click(STORY_LETTERS_ONLY, offset=True, interval=2):
+        if self.appear(STORY_LETTER_BLACK) and self.appear_then_click(STORY_LETTERS_ONLY, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
         if self.appear_then_click(STORY_CHOOSE, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
         if self.appear_then_click(STORY_CHOOSE_2, offset=True, interval=2):
+            self.story_popup_timout.start()
             return True
 
         return False
 
     def handle_story_skip(self):
         if not self.config.ENABLE_MAP_CLEAR_MODE:
+            return False
+        if self.config.ENABLE_FAST_FORWARD:
             return False
 
         return self.story_skip()

--- a/module/map/map_operation.py
+++ b/module/map/map_operation.py
@@ -40,6 +40,8 @@ class MapOperation(MysteryHandler, FleetPreparation, Retirement, FastForwardHand
         map_timer = Timer(1)
         fleet_timer = Timer(1)
         checked_in_map = False
+        self.stage_entrance = button
+
         while 1:
             self.device.screenshot()
 

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -17,7 +17,7 @@ class UI(ModuleBase):
         """
         return self.appear(page.check_button, offset=(20, 20))
 
-    def ui_click(self, click_button, check_button, appear_button=None, offset=(20, 20), retry_wait=3,
+    def ui_click(self, click_button, check_button, appear_button=None, offset=(20, 20), retry_wait=10,
                  skip_first_screenshot=False):
         """
         Args:


### PR DESCRIPTION
- Mis-detect BATTLE_STATUS_B when battle executing
- Mis-detect in_stage on potato device
- Optimize enemy_genre select for 12-2 leveling
Fix: Click low emotion warn as story confirm when fleet lock disabled
Fix: Infinite click on switch when switch is unknown 
- Increase ui retry interval for potato device