### PR TITLE
Fix: Mis-click auto switch if released torpedo at combat start

### DIFF
--- a/module/combat/combat.py
+++ b/module/combat/combat.py
@@ -211,7 +211,7 @@ class Combat(HPBalancer, EnemySearchingHandler, Retirement, SubmarineCall, Comba
                 continue
             if self.handle_combat_manual():
                 continue
-            if not auto and self.is_combat_executing():
+            if not auto and self.auto_mode_checked and self.is_combat_executing():
                 if self.handle_combat_weapon_release():
                     continue
             if call_submarine_at_boss:

--- a/module/reward/commission.py
+++ b/module/reward/commission.py
@@ -582,6 +582,7 @@ class RewardCommission(UI, InfoHandler):
 
         self.ui_goto(page_commission)
 
+        self.handle_info_bar()  # info_bar appears when get ship in Launch Ceremony commissions
         self.commission_start()
 
         self.ui_goto(page_reward, skip_first_screenshot=True)


### PR DESCRIPTION
Fix: Handle info_bar when get ship in Launch Ceremony commissions